### PR TITLE
Fixes some discrepencies with boolean values

### DIFF
--- a/spec/attrs.js
+++ b/spec/attrs.js
@@ -25,6 +25,7 @@ describe("attributes", () => {
     });
     it("are absent when falsy", () => {
       expect(renderAttrs({ disabled: false })).to.equal("");
+      expect(renderAttrs({ multiple: false })).to.equal("");
     });
   });
   describe("expecting objects", () => {
@@ -47,7 +48,7 @@ describe("attributes", () => {
     .to.equal(" href=\"/?this=that&amp;foo=bar\"");
   });
   it("that must be included are always included", () => {
-    expect(renderAttrs({ checked: false })).to.equal(" checked=\"false\"");
+    expect(renderAttrs({ checked: false })).to.equal("");
     expect(renderAttrs({ checked: true })).to.equal(" checked=\"true\"");
   });
   describe("expecting numbers", () => {

--- a/src/render/attrs/index.js
+++ b/src/render/attrs/index.js
@@ -40,15 +40,17 @@ function stringifyCustom (attr, value) {
 }
 
 function stringifyBoolean ({ attributeName: name, mustUseProperty }, value) {
+  if (!value) {
+    return "";
+  }
+
   let val;
 
   if (mustUseProperty) {
-    val = toStringWithValue(name, value);
-  } else if (value) {
-    val = name;
+    return toStringWithValue(name, value);
   }
 
-  return val;
+  return name;
 }
 
 function stringifyOverloadedBoolean (name, value) {


### PR DESCRIPTION
`{checked: false}` should return an empty string, same as `renderToString` does.

On the other hand, regular boolean attributes should be ignored when `false`, such as `multiple="false"`.

This pull request fixes both those issues by ignoring the boolean value when it is not true.

`mustUseProperty` is only used if the value is `true`, as seen in React codebase.